### PR TITLE
updates to behavior, tests, and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ or with html-loader:
 ### Original HTML
 
 ```html
-<img class="icon" height="1em" src="../%common/images/icons/camera.svg" />
+<svg class="icon" height="1em" src="../%common/images/icons/camera.svg" />
 ```
 
 ### Translated HTML

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markup-inline-loader",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "inline markups to HTML: SVG, MathML, etc.",
   "main": "index.js",
   "scripts": {
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/asnowwolf/markup-inline-loader#readme",
   "devDependencies": {
+    "mocha": "^2.5.3",
     "should": "^9.0.2"
   },
   "dependencies": {

--- a/test/complex.svg
+++ b/test/complex.svg
@@ -2,7 +2,8 @@
 <svg width="18px" height="19px" viewBox="0 0 18 19" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- This is comment -->
     <title>Some Title</title>
-    <desc>A complex svg for test 'svgo' </desc>
+    <desc>Created with Some Application.</desc>
+    <desc>Meaningful Description</desc>
     <defs></defs>
     <g id="Visual-Design" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" opacity="0.7" stroke-linejoin="round">
         <g id="login" transform="translate(-496.000000, -274.000000)" stroke-width="2">

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -15,19 +15,25 @@ function load(content, callback) {
 }
 
 describe('markup inline loader', function () {
-  it('svg', function () {
-    load('<svg class="abc" src="./basic.svg" width="100px" />').trim().should.equal('<svg class="abc"  width="100px"   viewBox="0 0 1024 1404.416" xmlns="http://www.w3.org/2000/svg"><path d="M960 440.384H704v-128c0-35.312-28.656-64-64-64H384c-35.344 0-64 28.688-64 64v128H192v-64H64v64c-35.344 0-64 28.688-64 64v704c0 35.376 28.656 64 64 64h896c35.344 0 64-28.624 64-64v-704c0-35.312-28.656-64-64-64zm-512-64h128v64H448v-64zm448 768H128v-576h768v576zm-384-128c106.032 0 192-85.938 192-192s-85.968-192-192-192-192 85.938-192 192 85.968 192 192 192zm0-256c35.344 0 64 28.624 64 64s-28.656 64-64 64-64-28.624-64-64 28.656-64 64-64z"/></svg>');
+  it('svg with attributes', function () {
+    load('<svg class=\'abc\' src="./basic.svg" width="100px" height="10px"></svg>').trim().should.equal('<svg class=\'abc\' width="100px" height="10px"  viewBox="0 0 1024 1404.416" xmlns="http://www.w3.org/2000/svg"><path d="M960 440.384H704v-128c0-35.312-28.656-64-64-64H384c-35.344 0-64 28.688-64 64v128H192v-64H64v64c-35.344 0-64 28.688-64 64v704c0 35.376 28.656 64 64 64h896c35.344 0 64-28.624 64-64v-704c0-35.312-28.656-64-64-64zm-512-64h128v64H448v-64zm448 768H128v-576h768v576zm-384-128c106.032 0 192-85.938 192-192s-85.968-192-192-192-192 85.938-192 192 85.968 192 192 192zm0-256c35.344 0 64 28.624 64 64s-28.656 64-64 64-64-28.624-64-64 28.656-64 64-64z"/></svg>');
   });
-  it('img', function () {
-    load('<img src="./basic.svg" />').trim().should.equal('<svg    viewBox="0 0 1024 1404.416" xmlns="http://www.w3.org/2000/svg"><path d="M960 440.384H704v-128c0-35.312-28.656-64-64-64H384c-35.344 0-64 28.688-64 64v128H192v-64H64v64c-35.344 0-64 28.688-64 64v704c0 35.376 28.656 64 64 64h896c35.344 0 64-28.624 64-64v-704c0-35.312-28.656-64-64-64zm-512-64h128v64H448v-64zm448 768H128v-576h768v576zm-384-128c106.032 0 192-85.938 192-192s-85.968-192-192-192-192 85.938-192 192 85.968 192 192 192zm0-256c35.344 0 64 28.624 64 64s-28.656 64-64 64-64-28.624-64-64 28.656-64 64-64z"/></svg>');
+  it('svg with single quotes', function () {
+    load('<svg src=\'./basic.svg\'></svg>').trim().should.equal('<svg    viewBox="0 0 1024 1404.416" xmlns="http://www.w3.org/2000/svg"><path d="M960 440.384H704v-128c0-35.312-28.656-64-64-64H384c-35.344 0-64 28.688-64 64v128H192v-64H64v64c-35.344 0-64 28.688-64 64v704c0 35.376 28.656 64 64 64h896c35.344 0 64-28.624 64-64v-704c0-35.312-28.656-64-64-64zm-512-64h128v64H448v-64zm448 768H128v-576h768v576zm-384-128c106.032 0 192-85.938 192-192s-85.968-192-192-192-192 85.938-192 192 85.968 192 192 192zm0-256c35.344 0 64 28.624 64 64s-28.656 64-64 64-64-28.624-64-64 28.656-64 64-64z"/></svg>');
   });
-  it('img & optimize', function () {
-    load('<img src="./complex.svg" />').trim().should.eql('<svg    width="18" height="19" viewBox="0 0 18 19" xmlns="http://www.w3.org/2000/svg"><path d="M9 9c2.2 0 4-1.8 4-4s-1.8-4-4-4-4 1.8-4 4 1.8 4 4 4zm0 3c-2.7 0-8 1.3-8 4v2h16v-2c0-2.7-5.3-4-8-4z" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round" opacity=".7" stroke-linejoin="round"/></svg>');
+  it('svg with self-closing tag', function () {
+    load('<svg src=\'./basic.svg\' />').trim().should.equal('<svg    viewBox="0 0 1024 1404.416" xmlns="http://www.w3.org/2000/svg"><path d="M960 440.384H704v-128c0-35.312-28.656-64-64-64H384c-35.344 0-64 28.688-64 64v128H192v-64H64v64c-35.344 0-64 28.688-64 64v704c0 35.376 28.656 64 64 64h896c35.344 0 64-28.624 64-64v-704c0-35.312-28.656-64-64-64zm-512-64h128v64H448v-64zm448 768H128v-576h768v576zm-384-128c106.032 0 192-85.938 192-192s-85.968-192-192-192-192 85.938-192 192 85.968 192 192 192zm0-256c35.344 0 64 28.624 64 64s-28.656 64-64 64-64-28.624-64-64 28.656-64 64-64z"/></svg>');
   });
-  it('other img', function () {
-    load('<img src="./test.jpg" />').trim().should.equal('<img src="./test.jpg" />');
+  it('svg with incorrect self-closing tag', function () {
+    load('<svg src="./basic.svg" /></svg>').trim().should.equal('<svg    viewBox="0 0 1024 1404.416" xmlns="http://www.w3.org/2000/svg"><path d="M960 440.384H704v-128c0-35.312-28.656-64-64-64H384c-35.344 0-64 28.688-64 64v128H192v-64H64v64c-35.344 0-64 28.688-64 64v704c0 35.376 28.656 64 64 64h896c35.344 0 64-28.624 64-64v-704c0-35.312-28.656-64-64-64zm-512-64h128v64H448v-64zm448 768H128v-576h768v576zm-384-128c106.032 0 192-85.938 192-192s-85.968-192-192-192-192 85.938-192 192 85.968 192 192 192zm0-256c35.344 0 64 28.624 64 64s-28.656 64-64 64-64-28.624-64-64 28.656-64 64-64z"/></svg></svg>');
+  });
+  it('svg with whitespace & optimize', function () {
+    load('< svg src =  "./complex.svg" > \n </ svg >').trim().should.eql('<svg    width="18" height="19" viewBox="0 0 18 19" xmlns="http://www.w3.org/2000/svg"><desc>Meaningful Description</desc><path d="M9 9c2.2 0 4-1.8 4-4s-1.8-4-4-4-4 1.8-4 4 1.8 4 4 4zm0 3c-2.7 0-8 1.3-8 4v2h16v-2c0-2.7-5.3-4-8-4z" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round" opacity=".7" stroke-linejoin="round"/></svg>');
+  });
+  it('inline svg', function () {
+    load('<svg class="blue"><path></path></svg>').trim().should.equal('<svg class="blue"><path></path></svg>');
   });
   it('math', function () {
-    load('<math src="./test.mml" />').trim().should.equal('<math style="display: block;"></math>');
+    load('<math class="test" src="./test.mml"></math>').trim().should.equal('<math class="test"   style="display: block;">test</math>');
   });
 });

--- a/test/test.mml
+++ b/test/test.mml
@@ -1,1 +1,1 @@
-<math style="display: block;"></math>
+<math style="display: block;">test</math>


### PR DESCRIPTION
Hi there -

Thanks for this loader - it was very close to what I needed for our project.

I've made some updates that you are welcome to take if you'd like. However beware that the changes are API-breaking, so a major version bump on NPM would be required.

* handle whitespace better
* handle both single and double-quotes
* handle both `<svg src="..." />` and `<svg src="..."></svg>` (the latter being standard HTML5)
* removed handling of `img` tags. Our webpack setup already has behavior for base64-inlining of src attributes, and I want to avoid conflicts with the existing behavior. On the other hand, adding a `src` attribute to `svg` elements is non-standard, so there's no conflict.

thanks!
