### PR TITLE
Handle alias mapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const PATTERN = /<(svg|img|math)\s+(.*?)src="(.*?)"(.*?)\/?>/gi;
+const PATTERN = /<(svg|img|math|i)\s+(.*?)src="(.*?)"(.*?)\/?>/gi;
 
 const fs = require('fs');
 const path = require('path');
@@ -23,8 +23,9 @@ module.exports = function(content) {
   let replacer = function(match, element, preAttributes, fileName, postAttributes, offset, string, done) {
     const isSvgFile = path.extname(fileName).toLowerCase() === '.svg';
     const isImg = element.toLowerCase() === 'img';
+    const isIcon = element.toLowerCase() === 'i';
 
-    if (!isSvgFile && isImg) {
+    if (!isSvgFile && (isImg || isIcon)) {
       done(null, match);
     } else {
       const filePath = loaderUtils.urlToRequest(fileName, options.root);

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
-var PATTERN = /<(svg|img|math)\s+(.*?)src="(.*?)"(.*?)\/?>/gi;
+const PATTERN = /<(svg|img|math)\s+(.*?)src="(.*?)"(.*?)\/?>/gi;
 
-var fs = require('fs');
-var path = require('path');
-var SVGO = require('svgo');
+const fs = require('fs');
+const path = require('path');
+const SVGO = require('svgo');
+const asyncReplace = require('async-replace');
 
-var svgo = new SVGO({
+const svgo = new SVGO({
   plugins: [
     {
       removeTitle: true
@@ -12,29 +13,39 @@ var svgo = new SVGO({
   ]
 });
 
-module.exports = function (content) {
+module.exports = function(content) {
   this.cacheable && this.cacheable();
-  var loader = this;
-  var loaderUtils = require('loader-utils');
-  content = content.replace(PATTERN, function (match, element, preAttributes, fileName, postAttributes) {
-    var isSvgFile = path.extname(fileName).toLowerCase() === '.svg';
-    var isImg = element.toLowerCase() === 'img';
+  const callback = this.async();
+  const loader = this;
+  const loaderUtils = require('loader-utils');
+  const options = loaderUtils.getOptions(this) || {};
+
+  let replacer = function(match, element, preAttributes, fileName, postAttributes, offset, string, done) {
+    const isSvgFile = path.extname(fileName).toLowerCase() === '.svg';
+    const isImg = element.toLowerCase() === 'img';
 
     if (!isSvgFile && isImg) {
-      return match;
-    }
+      done(null, match);
+    } else {
+      const filePath = loaderUtils.urlToRequest(fileName, options.root);
+      loader.resolve(loader.context, filePath, function(err, resolvedFilePath) {
+        if (err) done(err);
 
-    var filePath = path.join(loader.context, fileName);
-    filePath = loaderUtils.urlToRequest(filePath, '/');
-    loader.addDependency(filePath);
-    var fileContent = fs.readFileSync(filePath, {encoding: 'utf-8'});
-    if (isSvgFile) {
-      // It's callback, But it's sync
-      svgo.optimize(fileContent, function (result) {
-        fileContent = result.data;
+        loader.addDependency(resolvedFilePath);
+        let fileContent = fs.readFileSync(resolvedFilePath, {encoding: 'utf-8'});
+        if (isSvgFile) {
+          // It's callback, But it's sync
+          svgo.optimize(fileContent, function(result) {
+            fileContent = result.data;
+          });
+        }
+        let replacedContent = fileContent.replace(/^<svg/, '<svg ' + preAttributes + postAttributes + ' ')
+        done(null, replacedContent);
       });
     }
-    return fileContent.replace(/^<svg/, '<svg ' + preAttributes + postAttributes + ' ');
+  };
+
+  asyncReplace(content, PATTERN, replacer, function(err, result) {
+    callback(err, result);
   });
-  return content;
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "should": "^9.0.2"
   },
   "dependencies": {
-    "loader-utils": "^0.2.16",
+    "async-replace": "^1.0.1",
+    "loader-utils": "^1.0.2",
     "svgo": "^0.6.6"
   }
 }


### PR DESCRIPTION
This PR addresses https://github.com/asnowwolf/markup-inline-loader/issues/3 where the fix did not work in my testing.

I am new to webpack loaders, but it appears that the loader `resolve` method must be used to resolve alias mappings.  Unfortunately the sync version of the call `resolveSync` did not work for me and threw errors, so that led to some changes to support async operations.