### PR TITLE
Allow spaces around src tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var PATTERN = /<(svg|img|math)\s+(.*?)src="(.*?)"(.*?)\/?>/gi;
+var PATTERN = /<(svg|img|math)\s+(.*?)src(\s*)=(\s*)"(.*?)"(.*?)\/?>/gi;
 
 var fs = require('fs');
 var path = require('path');
@@ -16,7 +16,7 @@ module.exports = function (content) {
   this.cacheable && this.cacheable();
   var loader = this;
   var loaderUtils = require('loader-utils');
-  content = content.replace(PATTERN, function (match, element, preAttributes, fileName, postAttributes) {
+  content = content.replace(PATTERN, function (match, element, preAttributes, space1, space2, fileName, postAttributes) {
     var isSvgFile = path.extname(fileName).toLowerCase() === '.svg';
     var isImg = element.toLowerCase() === 'img';
 


### PR DESCRIPTION
This change will allow the following markup to match.

`
<svg src = "path/to/image.svg" />
`

This changes the regex to take the space between the src and =.