### PR TITLE
Update svgo to avoid vulnerability in js-jaml < 3.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "svgo": "^0.6.6"
+    "svgo": "1.3.0"
   }
 }


### PR DESCRIPTION
Patches svgo version in order to mitigate vulnerability described in [NPM advisories](https://www.npmjs.com/advisories/788)